### PR TITLE
Fix Semaphore Bug

### DIFF
--- a/cpp-lib/include/pitaya/cluster.h
+++ b/cpp-lib/include/pitaya/cluster.h
@@ -90,7 +90,7 @@ private:
     Server _server;
 
     utils::SyncDeque<RpcData> _waitingRpcs;
-    utils::Semaphore _waitingRpcsSemaphore;
+    std::unique_ptr<utils::Semaphore> _waitingRpcsSemaphore;
     bool _waitingRpcsFinished;
 };
 

--- a/cpp-lib/include/pitaya/nats_client.h
+++ b/cpp-lib/include/pitaya/nats_client.h
@@ -64,8 +64,6 @@ public:
     virtual NatsStatus Subscribe(const std::string& topic,
                                  std::function<void(std::shared_ptr<NatsMsg>)> onMessage) = 0;
 
-    virtual void Unsubscribe() = 0;
-
     virtual NatsStatus Publish(const char* reply, const std::vector<uint8_t>& buf) = 0;
 };
 
@@ -82,8 +80,6 @@ public:
 
     NatsStatus Subscribe(const std::string& topic,
                          std::function<void(std::shared_ptr<NatsMsg>)> onMessage) override;
-
-    void Unsubscribe() override;
 
     NatsStatus Publish(const char* reply, const std::vector<uint8_t>& buf) override;
 

--- a/cpp-lib/src/pitaya/nats/rpc_client.cpp
+++ b/cpp-lib/src/pitaya/nats/rpc_client.cpp
@@ -24,7 +24,7 @@ namespace pitaya {
 NatsRpcClient::NatsRpcClient(const NatsConfig& config, const char* loggerName)
     : NatsRpcClient(
           config,
-          std::unique_ptr<NatsClient>(new NatsClientImpl(NatsApiType::Synchronous, config)),
+          std::unique_ptr<NatsClient>(new NatsClientImpl(NatsApiType::Synchronous, config, loggerName)),
           loggerName)
 {}
 

--- a/cpp-lib/src/pitaya/nats/rpc_server.cpp
+++ b/cpp-lib/src/pitaya/nats/rpc_server.cpp
@@ -86,7 +86,7 @@ NatsRpcServer::NatsRpcServer(const Server& server, const NatsConfig& config, con
     : NatsRpcServer(
           server,
           config,
-          std::unique_ptr<NatsClient>(new NatsClientImpl(NatsApiType::Asynchronous, config)),
+          std::unique_ptr<NatsClient>(new NatsClientImpl(NatsApiType::Asynchronous, config, loggerName)),
           loggerName)
 {}
 
@@ -102,6 +102,7 @@ NatsRpcServer::NatsRpcServer(const Server& server,
 
 NatsRpcServer::~NatsRpcServer()
 {
+    _log->info("Stopping rpc server");
     _log->flush();
 }
 

--- a/cpp-lib/src/pitaya_cluster.cpp
+++ b/cpp-lib/src/pitaya_cluster.cpp
@@ -119,8 +119,8 @@ main()
                                                server,
                                                "main");
 #else
-        NatsConfig natsConfig("nats://localhost:4222", 1000, 3000, 3, 100);
-
+        NatsConfig natsConfig("nats://localhost:4222", std::chrono::milliseconds(1000), std::chrono::milliseconds(3000), std::chrono::milliseconds(3), 100, 3, 10);
+        
         Cluster::Instance().InitializeWithNats(
             std::move(natsConfig), std::move(sdConfig), server, "main");
 #endif

--- a/cpp-lib/test/cluster_test.cpp
+++ b/cpp-lib/test/cluster_test.cpp
@@ -213,11 +213,11 @@ TEST_F(ClusterTest, SemaphoreRestart)
     
     for (auto& thread : rpcListeners) {
         thread = std::thread([]() {
-            auto start = std::chrono::system_clock::now();
+            auto start = high_resolution_clock::now();
             optional<Cluster::RpcData> data = Cluster::Instance().WaitForRpc();
-            auto end = std::chrono::system_clock::now();
-            std::chrono::duration<double> elapsed_seconds = end-start;
-            EXPECT_GE(elapsed_seconds, std::chrono::duration<double>(0.050));
+            auto end = high_resolution_clock::now();
+            auto elapsed_ns = duration_cast<nanoseconds>(end-start).count();
+            EXPECT_GE(elapsed_ns, duration_cast<nanoseconds>(milliseconds(50)).count());
             EXPECT_EQ(data, boost::none);
         });
     }

--- a/cpp-lib/test/cluster_test.cpp
+++ b/cpp-lib/test/cluster_test.cpp
@@ -197,3 +197,39 @@ TEST_F(ClusterTest, ThreadsWaitingForRpcsReceiveFinishedNotification)
         }
     }
 }
+
+TEST_F(ClusterTest, SemaphoreRestart)
+{
+    using namespace std::chrono;
+    
+    EXPECT_NE(_handlerFunc, nullptr);
+    EXPECT_CALL(*_mockRpcSv, Shutdown()).WillOnce(SendEmptyRpc(_handlerFunc));
+    
+    Cluster::Instance().Terminate();
+    SetUp();
+    
+    // Define 10 threads waiting for RPCs
+    std::vector<std::thread> rpcListeners(10);
+    
+    for (auto& thread : rpcListeners) {
+        thread = std::thread([]() {
+            auto start = std::chrono::system_clock::now();
+            optional<Cluster::RpcData> data = Cluster::Instance().WaitForRpc();
+            auto end = std::chrono::system_clock::now();
+            std::chrono::duration<double> elapsed_seconds = end-start;
+            EXPECT_GE(elapsed_seconds, std::chrono::duration<double>(0.050));
+            EXPECT_EQ(data, boost::none);
+        });
+    }
+    
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    
+    EXPECT_CALL(*_mockRpcSv, Shutdown()).WillOnce(SendEmptyRpc(_handlerFunc));
+    Cluster::Instance().Terminate();
+    
+    for (auto& thread : rpcListeners) {
+        if (thread.joinable()) {
+            thread.join();
+        }
+    }
+}

--- a/cpp-lib/test/mock_nats_client.h
+++ b/cpp-lib/test/mock_nats_client.h
@@ -19,8 +19,6 @@ public:
         pitaya::NatsStatus(const std::string& topic,
                            std::function<void(std::shared_ptr<pitaya::NatsMsg>)> onMessage));
 
-    MOCK_METHOD0(Unsubscribe, void());
-
     MOCK_METHOD2(Publish, pitaya::NatsStatus(const char* reply, const std::vector<uint8_t>& buf));
 };
 


### PR DESCRIPTION
**Description**

Change semaphore to be a pointer, so it is possible to reset it on start and so that on terminating it will not crash due to other threads referring to it.

The bug was detected when using UNITY and noticing the semaphore was still the same one from the last time which was created.