### PR TITLE
Add exponential backoff for ETCD connection retry

### DIFF
--- a/cpp-lib/include/pitaya/c_wrapper.h
+++ b/cpp-lib/include/pitaya/c_wrapper.h
@@ -39,6 +39,7 @@ struct CSDConfig
     int32_t logServerDetails;
     int32_t syncServersIntervalSec;
     int32_t maxNumberOfRetries;
+    int32_t retryDelayMilliseconds;
 
     bool TryGetConfig(pitaya::EtcdServiceDiscoveryConfig& config);
 };

--- a/cpp-lib/include/pitaya/etcd_config.h
+++ b/cpp-lib/include/pitaya/etcd_config.h
@@ -16,11 +16,13 @@ struct EtcdServiceDiscoveryConfig
     bool logServerSync;
     bool logServerDetails;
     std::chrono::seconds syncServersIntervalSec;
-    // TODO, FIXME(leo): Currently there is no exponential backoff for this parameter.
     int32_t maxNumberOfRetries;
     // List of server types to filter. This filter will be added on top
     // of the etcdPrefix.
     std::vector<std::string> serverTypeFilters;
+    // Delay used on the exponential backoff retry (given in
+    // milliseconds).
+    int32_t retryDelayMilliseconds;
 
     EtcdServiceDiscoveryConfig()
         : heartbeatTTLSec(std::chrono::seconds(60))
@@ -29,6 +31,7 @@ struct EtcdServiceDiscoveryConfig
         , logServerDetails(false)
         , syncServersIntervalSec(std::chrono::seconds(60))
         , maxNumberOfRetries(10)
+        , retryDelayMilliseconds(100)
     {}
 };
 

--- a/cpp-lib/src/pitaya/c_wrapper.cpp
+++ b/cpp-lib/src/pitaya/c_wrapper.cpp
@@ -143,6 +143,7 @@ CSDConfig::TryGetConfig(pitaya::EtcdServiceDiscoveryConfig& config)
     config.logServerDetails = logServerDetails;
     config.syncServersIntervalSec = std::chrono::seconds(syncServersIntervalSec);
     config.maxNumberOfRetries = maxNumberOfRetries;
+    config.retryDelayMilliseconds = retryDelayMilliseconds;
     return ParseServerTypeFilters(config.serverTypeFilters, this->serverTypeFilters);
 }
 

--- a/cpp-lib/src/pitaya/etcdv3_service_discovery/worker.cpp
+++ b/cpp-lib/src/pitaya/etcdv3_service_discovery/worker.cpp
@@ -216,8 +216,13 @@ Worker::StartThread()
                 _syncServersTicker.Stop();
 
                 while (_numKeepAliveRetriesLeft > 0) {
+                    auto delay_milliseconds = _config.retryDelayMilliseconds << ((_config.maxNumberOfRetries - _numKeepAliveRetriesLeft) - 1);
+                    _log->info("delaying retry by {}ms", delay_milliseconds);
+                    std::this_thread::sleep_for(std::chrono::milliseconds(delay_milliseconds));
+
                     --_numKeepAliveRetriesLeft;
                     auto ok = Bootstrap();
+
                     if (ok) {
                         _log->info("Etcd reconnection successful");
                         // FIXME(leo): Do not reset the number of keep alive retries yet,

--- a/pitaya-sharp/ExampleEFCore/src/App.cs
+++ b/pitaya-sharp/ExampleEFCore/src/App.cs
@@ -25,7 +25,8 @@ namespace ExampleORM
                 logServerSync: true,
                 logServerDetails: true,
                 syncServersIntervalSec: 30,
-                maxNumberOfRetries: 0);
+                maxNumberOfRetries: 0,
+                retryDelayMilliseconds: 0);
 
             var sv = new Server(
                 id: serverId,

--- a/pitaya-sharp/NPitaya/src/NativeInterop.cs
+++ b/pitaya-sharp/NPitaya/src/NativeInterop.cs
@@ -70,9 +70,10 @@ namespace NPitaya
         public int logServerDetails;
         public int syncServersIntervalSec;
         public int maxNumberOfRetries;
+        public int retryDelayMilliseconds;
 
         public SDConfig(string endpoints, string etcdPrefix, List<string> serverTypeFilters, int heartbeatTTLSec, bool logHeartbeat,
-            bool logServerSync, bool logServerDetails, int syncServersIntervalSec, int maxNumberOfRetries)
+            bool logServerSync, bool logServerDetails, int syncServersIntervalSec, int maxNumberOfRetries, int retryDelayMilliseconds)
         {
             this.endpoints = endpoints;
             this.etcdPrefix = etcdPrefix;
@@ -82,6 +83,7 @@ namespace NPitaya
             this.logServerDetails = Convert.ToInt32(logServerDetails);
             this.syncServersIntervalSec = syncServersIntervalSec;
             this.maxNumberOfRetries = maxNumberOfRetries;
+            this.retryDelayMilliseconds = retryDelayMilliseconds;
             try
             {
                 serverTypeFiltersStr = SimpleJson.SerializeObject(serverTypeFilters);

--- a/pitaya-sharp/exampleapp/Program.cs
+++ b/pitaya-sharp/exampleapp/Program.cs
@@ -29,7 +29,8 @@ namespace PitayaCSharpExample
         logServerSync: true,
         logServerDetails: true,
         syncServersIntervalSec: 30,
-        maxNumberOfRetries: 0);
+        maxNumberOfRetries: 0,
+        retryDelayMilliseconds: 0);
 
       var sv = new Server(
           id: serverId,

--- a/unity-example/Assets/LibPitayaExample.cs
+++ b/unity-example/Assets/LibPitayaExample.cs
@@ -38,7 +38,8 @@ public class LibPitayaExample : MonoBehaviour {
 		    logServerSync: true,
 		    logServerDetails: false,
 		    syncServersIntervalSec: 60,
-		    maxNumberOfRetries: 10);
+		    maxNumberOfRetries: 10,
+		    retryDelayMilliseconds: 100);
 
         var grpcConfig = new GrpcConfig(
             host: "127.0.0.1",


### PR DESCRIPTION
This PR introduces an exponential delay increase in the reconnection after each retry. In addition, it introduces a new configuration, `retryDelayMilliseconds` (given in an integer), that defines the base delay.