### PR TITLE
Add windows build for cpp-lib

### DIFF
--- a/cpp-lib/Makefile
+++ b/cpp-lib/Makefile
@@ -69,6 +69,16 @@ build-mac-unity-debug:
 	@cmake --preset npitaya-macos-$(LOCAL_ARCH)-macosx_bundle_true-debug
 	@cmake --build --preset npitaya-macos-$(LOCAL_ARCH)-macosx_bundle_true-debug
 
+build-windows-release:
+	@conan install . -s arch=x86_64 --build=missing -pr ./conanprofile -s compiler.cppstd=17
+	@cmake --preset npitaya-windows-x86_64-release
+	@cmake --build --preset npitaya-windows-x86_64-release
+
+build-windows-debug:
+	@conan install . --build=missing -pr ./conanprofile -s compiler.cppstd=17 -s build_type=Debug -c tools.build:skip_test=False -s compiler.runtime_type=Debug
+	@cmake --preset npitaya-windows-x86_64-debug -DBUILD_GMOCK=ON
+	@cmake --build --preset npitaya-windows-x86_64-debug
+
 build-docker-image:
 	@docker build . -t pitaya-cluster
 
@@ -79,3 +89,6 @@ build-all-mac: build-mac-release build-mac-unity build-linux-docker
 
 run-mac-debug:
 	cmake --build --preset npitaya-macos-$(LOCAL_ARCH)-macosx_bundle_false-debug && ./run-tests-with-coverage.sh _builds/macos-$(LOCAL_ARCH)-macosx_bundle_false-debug/tests
+
+run-windows-debug:
+	cmake --build --preset npitaya-windows-x86_64-debug && _builds\windows-x86_64-debug\Debug\tests

--- a/cpp-lib/src/pitaya/etcdv3_service_discovery/worker.cpp
+++ b/cpp-lib/src/pitaya/etcdv3_service_discovery/worker.cpp
@@ -243,6 +243,7 @@ Worker::StartThread()
                 if (_numKeepAliveRetriesLeft <= 0) {
                     _log->critical("Failed to reconnect to etcd, shutting down");
                     Shutdown();
+                    // TODO: signalize termination on Windows
                     std::thread(std::bind(raise, SIGTERM)).detach();
                     _log->debug("Exiting loop");
                     return;

--- a/cpp-lib/src/pitaya_cluster.cpp
+++ b/cpp-lib/src/pitaya_cluster.cpp
@@ -18,6 +18,10 @@
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <thread>
 
+#ifdef _WIN32
+#include <signal.h>
+#endif
+
 using namespace pitaya;
 using pitaya::service_discovery::ServiceDiscovery;
 
@@ -87,7 +91,6 @@ main()
 #if 1
     signal(SIGTERM, SignalHandler);
     signal(SIGINT, SignalHandler);
-
     auto logger = spdlog::stdout_color_mt("main");
     logger->set_level(spdlog::level::debug);
 

--- a/cpp-lib/test/nats_rpc_server_test.cpp
+++ b/cpp-lib/test/nats_rpc_server_test.cpp
@@ -116,7 +116,7 @@ TEST_F(NatsRpcServerTest, CanHandleRpcs)
         std::vector<uint8_t> serverResponseBuf(serverResponse.ByteSizeLong());
         serverResponse.SerializeToArray(serverResponseBuf.data(), serverResponseBuf.size());
 
-        EXPECT_CALL(*mockClient, Publish("my.reply.server", serverResponseBuf))
+        EXPECT_CALL(*mockClient, Publish(StrEq("my.reply.server"), serverResponseBuf))
             .WillOnce(Return(NATS_OK));
     }
 
@@ -177,7 +177,7 @@ TEST_F(NatsRpcServerTest, HasGracefulShutdown)
         std::vector<uint8_t> serverResponseBuf(serverResponse.ByteSizeLong());
         serverResponse.SerializeToArray(serverResponseBuf.data(), serverResponseBuf.size());
 
-        EXPECT_CALL(*mockClient, Publish("my.reply.server", serverResponseBuf))
+        EXPECT_CALL(*mockClient, Publish(StrEq("my.reply.server"), serverResponseBuf))
             .WillOnce(Return(NATS_OK));
     }
 

--- a/cpp-lib/test/ticker_test.cpp
+++ b/cpp-lib/test/ticker_test.cpp
@@ -2,6 +2,11 @@
 
 #include "pitaya/utils/ticker.h"
 
+#ifdef _WIN32
+#include <windows.h>
+#pragma comment(lib, "winmm.lib") // for timeBeginPeriod
+#endif
+
 using namespace ::testing;
 using namespace pitaya::utils;
 
@@ -24,23 +29,46 @@ TEST(Ticker, CallbackIsNotCalledIfNotStarted)
 
 TEST(Ticker, CallbackIsCalledIfStarted)
 {
+#ifdef _WIN32
+    UINT resolutionSetResult = timeBeginPeriod(5);
+    if (resolutionSetResult == TIMERR_NOCANDO) {
+        GTEST_SKIP() << "Windows can't ensure time resolution required.";
+    }
+#endif
+
     bool called = false;
     Ticker ticker(std::chrono::milliseconds(10), [&]() { called = true; });
 
     ticker.Start();
     std::this_thread::sleep_for(std::chrono::milliseconds(20));
     ticker.Stop();
+
+#ifdef _WIN32
+    timeEndPeriod(5);
+#endif
+
     ASSERT_TRUE(called);
 }
 
 TEST(Ticker, CallbackIsNotCalledIfStartedAndStopped)
 {
+#ifdef _WIN32
+    UINT resolutionSetResult = timeBeginPeriod(5);
+    if(resolutionSetResult == TIMERR_NOCANDO){
+        GTEST_SKIP() << "Windows can't ensure time resolution required.";
+    }
+#endif
+
     bool called = false;
     Ticker ticker(std::chrono::milliseconds(10), [&]() { called = true; });
-
+    
     ticker.Start();
     std::this_thread::sleep_for(std::chrono::milliseconds(5));
     ticker.Stop();
+
+#ifdef _WIN32
+    timeEndPeriod(5);
+#endif
 
     std::this_thread::sleep_for(std::chrono::milliseconds(20));
     ASSERT_FALSE(called);
@@ -70,6 +98,10 @@ TEST(Ticker, DoesNotRespectTheIntervalForReallySmallOnes)
     EXPECT_LT(called, 95);
 }
 
+// The test below is not valid on Windows, as its launch::async policy is
+// implemented as launch::async|launch::deferred, not guaranteeing that the
+// callback will be executed in a different thread.
+#ifndef _WIN32
 TEST(Ticker, CallbackIsNotCalledFromTheMainThread)
 {
     auto callbackThreadId = std::this_thread::get_id();
@@ -83,3 +115,4 @@ TEST(Ticker, CallbackIsNotCalledFromTheMainThread)
 
     EXPECT_NE(callbackThreadId, std::this_thread::get_id());
 }
+#endif


### PR DESCRIPTION
### Overview
This PR brings a Windows build for the cpp-lib. 

### Details
A few changes were necessary to allow the lib to compile under MSVC, listed below:
- `compiler.cppstd=17` instead of `compiler.cppstd=gnu17`
- Usage of matcher `StrEq` on a few tests. Under MSVC, it was seeing two string literals as different addresses, failing tests. Adding this matcher should not influence the others builds, as it is even the preferable way of using Google Test.
- A few tests required setting a higher resolution for timers with `timeBeginPeriod`. Windows seems to have a default resolution of 15.6ms, causing the tests to break occasionally.
- The test `CallbackIsNotCalledFromTheMainThread` in `ticker_test.cpp` was removed from Windows builds, because `launch::async` policy is implemented as `launch::async|launch::deferred` in MSVC, not guaranteeing that the callback will be executed in a different thread. (reference https://learn.microsoft.com/en-us/cpp/standard-library/future-functions?view=msvc-170)

To build it, I have created the following targets in the Makefile: `build-windows-release`, `build-windows-debug`
And to test, it is possible to use `run-windows-debug`.

### TODO
Windows doesn't handle signals in a straightforward way like UNIX. 
Registering a signal and a handler with `signal(SIGTERM, SignalHandler)` and emitting the signal after does not behave like UNIX and I could not find a good way to it for now. This breaks the test `Etcdv3ServiceDiscoveryTest, FailsAfterMaxRetriesUsingExponentialBackoff`, which is returning the following on my system (Windows 11, MSVC 14.39, x86):
```
Result: died but not with expected exit code:
            Exited with exit status 3
```
I'm not sure why it is returning `status 3`, but it is clear that the worker raising SIGTERM when `_numKeepAliveRetriesLeft <= 0` is not working as expected for Windows. 