### PR TITLE
fix(nats): tune reconnect params

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -2,7 +2,10 @@ name: Build and Release NPitaya Native Libraries
 on:
   push:
     tags:
-      - '*'
+      - "*"
+  pull_request:
+    branches:
+      - master
 
 env:
   BUILD_TYPE: Release
@@ -19,9 +22,8 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: downloaded-artifacts
-          key: compiled-libs-${{ github.ref_name }}-${{ hashFiles('cpp-lib/conanfile.py', 'cpp-lib/conanprofile', 'cpp-lib/CMakeLists.txt', 'cpp-lib/src/**/*', 'cpp-lib/include/**/*', 'vendor/**/*') }}
+          key: compiled-libs-${{ hashFiles('cpp-lib/conanfile.py', 'cpp-lib/conanprofile', 'cpp-lib/CMakeLists.txt', 'cpp-lib/src/**/*', 'cpp-lib/include/**/*', 'vendor/**/*') }}
           restore-keys: |
-            compiled-libs-${{ github.ref_name }}-
             compiled-libs-
 
       - name: Check if cache was restored
@@ -80,95 +82,95 @@ jobs:
             runner: macos-latest
             cmake_path: build/_builds/Release
     steps:
-    - name: Install Conan
-      id: conan
-      uses: turtlebrowser/get-conan@main
-      env:
-        PIP_BREAK_SYSTEM_PACKAGES: 1
+      - name: Install Conan
+        id: conan
+        uses: turtlebrowser/get-conan@main
+        env:
+          PIP_BREAK_SYSTEM_PACKAGES: 1
 
-    - name: Optimize Conan
-      run: |
-        # Show Conan version and available commands
-        conan --version
-        conan config list
-        conan profile detect
-        conan remote add conancenter https://center.conan.io || true
-        conan remote list
+      - name: Optimize Conan
+        run: |
+          # Show Conan version and available commands
+          conan --version
+          conan config list
+          conan profile detect
+          conan remote add conancenter https://center.conan.io || true
+          conan remote list
 
-    - uses: actions/checkout@v4
-      with:
-        submodules: recursive
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
-    - name: Install build tools (Linux)
-      if: matrix.os == 'ubuntu-22.04'
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y cmake make g++ gcc
+      - name: Install build tools (Linux)
+        if: matrix.os == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake make g++ gcc
 
-    - name: Install Numpy for macOS builds
-      if: matrix.os == 'macos-latest'
-      run: pip3 install numpy --break-system-packages
+      - name: Install Numpy for macOS builds
+        if: matrix.os == 'macos-latest'
+        run: pip3 install numpy --break-system-packages
 
-    - name: Using the builtin GitHub Cache Action for .conan
-      id: cache-conan-restore
-      uses: actions/cache/restore@v3
-      env:
-        cache-name: cache-conan-modules
-      with:
-        path: ~/.conan2/
-        key: ${{ runner.os }}-${{ matrix.arch }}-builder-${{ env.cache-name }}-${{ hashFiles('cpp-lib/conanfile.py', 'cpp-lib/conanprofile') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.arch }}-builder-${{ env.cache-name }}-
-          ${{ runner.os }}-${{ matrix.arch }}-builder-
+      - name: Using the builtin GitHub Cache Action for .conan
+        id: cache-conan-restore
+        uses: actions/cache/restore@v3
+        env:
+          cache-name: cache-conan-modules
+        with:
+          path: ~/.conan2/
+          key: ${{ runner.os }}-${{ matrix.arch }}-builder-${{ env.cache-name }}-${{ hashFiles('cpp-lib/conanfile.py', 'cpp-lib/conanprofile') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.arch }}-builder-${{ env.cache-name }}-
+            ${{ runner.os }}-${{ matrix.arch }}-builder-
 
-    - name: Install Conan Dependencies - Ubuntu
-      if: matrix.os == 'ubuntu-22.04'
-      env:
-        CONAN_PARALLEL_DOWNLOAD: 8
-        CONAN_PARALLEL_BUILD: 4
-      run: conan install . -of build -s build_type=${{env.BUILD_TYPE}} -s arch=${{matrix.arch}} -s:b compiler.cppstd=${{ matrix.cppstd }} -s compiler.cppstd=${{ matrix.cppstd }} -o "*:shared=False" -o "protobuf/*:debug_suffix=False" -o "openssl/*:shared=False" -o "cpprestsdk/*:with_websockets=False" --build=missing --build=outdated
-      working-directory: cpp-lib
+      - name: Install Conan Dependencies - Ubuntu
+        if: matrix.os == 'ubuntu-22.04'
+        env:
+          CONAN_PARALLEL_DOWNLOAD: 8
+          CONAN_PARALLEL_BUILD: 4
+        run: conan install . -of build -s build_type=${{env.BUILD_TYPE}} -s arch=${{matrix.arch}} -s:b compiler.cppstd=${{ matrix.cppstd }} -s compiler.cppstd=${{ matrix.cppstd }} -o "*:shared=False" -o "protobuf/*:debug_suffix=False" -o "openssl/*:shared=False" -o "cpprestsdk/*:with_websockets=False" --build=missing --build=outdated
+        working-directory: cpp-lib
 
-    - name: Install Conan Dependencies - Windows
-      if: matrix.os == 'windows-latest'
-      env:
-        CONAN_PARALLEL_DOWNLOAD: 8
-        CONAN_PARALLEL_BUILD: 4
-      run: conan install . -of build -s build_type=${{env.BUILD_TYPE}} -s arch=${{matrix.arch}} -s:b compiler.cppstd=${{ matrix.cppstd }} -s compiler.cppstd=${{ matrix.cppstd }} -o "*:shared=False" -o "protobuf/*:debug_suffix=False" -o "openssl/*:shared=False" -o "cpprestsdk/*:with_websockets=False" --build=missing --build=outdated
-      working-directory: cpp-lib
+      - name: Install Conan Dependencies - Windows
+        if: matrix.os == 'windows-latest'
+        env:
+          CONAN_PARALLEL_DOWNLOAD: 8
+          CONAN_PARALLEL_BUILD: 4
+        run: conan install . -of build -s build_type=${{env.BUILD_TYPE}} -s arch=${{matrix.arch}} -s:b compiler.cppstd=${{ matrix.cppstd }} -s compiler.cppstd=${{ matrix.cppstd }} -o "*:shared=False" -o "protobuf/*:debug_suffix=False" -o "openssl/*:shared=False" -o "cpprestsdk/*:with_websockets=False" --build=missing --build=outdated
+        working-directory: cpp-lib
 
-    - name: Install Conan Dependencies - macOS
-      if: matrix.os == 'macos-latest'
-      env:
-        CONAN_PARALLEL_DOWNLOAD: 8
-        CONAN_PARALLEL_BUILD: 4
-      run: |
-        # macOS-specific flags for Apple Clang 15 compatibility
-        conan install . -of build -s build_type=${{env.BUILD_TYPE}} -s arch=${{matrix.arch}} -s:b compiler.cppstd=${{ matrix.cppstd }} -s compiler.cppstd=${{ matrix.cppstd }} -s:b compiler.libcxx=libc++ -s compiler.libcxx=libc++ -s:b compiler.version=15 -s compiler.version=15 -o "*:shared=False" -o "protobuf/*:debug_suffix=False" -o "openssl/*:shared=False" -o "cpprestsdk/*:with_websockets=False" --build=missing --build=outdated
-      working-directory: cpp-lib
+      - name: Install Conan Dependencies - macOS
+        if: matrix.os == 'macos-latest'
+        env:
+          CONAN_PARALLEL_DOWNLOAD: 8
+          CONAN_PARALLEL_BUILD: 4
+        run: |
+          # macOS-specific flags for Apple Clang 15 compatibility
+          conan install . -of build -s build_type=${{env.BUILD_TYPE}} -s arch=${{matrix.arch}} -s:b compiler.cppstd=${{ matrix.cppstd }} -s compiler.cppstd=${{ matrix.cppstd }} -s:b compiler.libcxx=libc++ -s compiler.libcxx=libc++ -s:b compiler.version=15 -s compiler.version=15 -o "*:shared=False" -o "protobuf/*:debug_suffix=False" -o "openssl/*:shared=False" -o "cpprestsdk/*:with_websockets=False" --build=missing --build=outdated
+        working-directory: cpp-lib
 
-    - name: Configure CMake
-      run: cmake --preset ${{matrix.preset}} -DBUILD_TESTING=OFF
-      working-directory: cpp-lib
+      - name: Configure CMake
+        run: cmake --preset ${{matrix.preset}} -DBUILD_TESTING=OFF
+        working-directory: cpp-lib
 
-    - name: Build
-      run: cmake --build ${{matrix.cmake_path}} --config ${{env.BUILD_TYPE}} --target pitaya_cpp
-      working-directory: cpp-lib
+      - name: Build
+        run: cmake --build ${{matrix.cmake_path}} --config ${{env.BUILD_TYPE}} --target pitaya_cpp
+        working-directory: cpp-lib
 
-    - uses: actions/cache/save@v3
-      env:
-        cache-name: cache-conan-modules
-      with:
-        path: ~/.conan2/
-        key: ${{ runner.os }}-${{ matrix.arch }}-builder-${{ env.cache-name }}-${{ hashFiles('cpp-lib/conanfile.py', 'cpp-lib/conanprofile') }}
+      - uses: actions/cache/save@v3
+        env:
+          cache-name: cache-conan-modules
+        with:
+          path: ~/.conan2/
+          key: ${{ runner.os }}-${{ matrix.arch }}-builder-${{ env.cache-name }}-${{ hashFiles('cpp-lib/conanfile.py', 'cpp-lib/conanprofile') }}
 
-    - uses: actions/upload-artifact@v4
-      with:
-        name: prebuilt-libs-${{ matrix.platform }}
-        path: |
-          cpp-lib/build/**/*pitaya_cpp.dll
-          cpp-lib/build/**/*pitaya_cpp.so
-          cpp-lib/build/**/*pitaya_cpp.dylib
+      - uses: actions/upload-artifact@v4
+        with:
+          name: prebuilt-libs-${{ matrix.platform }}
+          path: |
+            cpp-lib/build/**/*pitaya_cpp.dll
+            cpp-lib/build/**/*pitaya_cpp.so
+            cpp-lib/build/**/*pitaya_cpp.dylib
 
   consolidate:
     name: Consolidate all libs into single package
@@ -186,7 +188,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: downloaded-artifacts
-          key: compiled-libs-${{ github.ref_name }}-${{ hashFiles('cpp-lib/conanfile.py', 'cpp-lib/conanprofile', 'cpp-lib/CMakeLists.txt', 'cpp-lib/src/**/*', 'cpp-lib/include/**/*', 'vendor/**/*') }}
+          key: compiled-libs-${{ hashFiles('cpp-lib/conanfile.py', 'cpp-lib/conanprofile', 'cpp-lib/CMakeLists.txt', 'cpp-lib/src/**/*', 'cpp-lib/include/**/*', 'vendor/**/*') }}
 
       - name: Process Libs
         if: needs.cache-check.outputs.cache-hit != 'true'
@@ -223,7 +225,7 @@ jobs:
           find . -name "*.so" -o -name "*.dylib" -o -name "*.dll" | sort
         working-directory: downloaded-artifacts
 
-      - name: 'Upload Artifact'
+      - name: "Upload Artifact"
         uses: actions/upload-artifact@v4
         with:
           name: prebuilt-libs-all-archs
@@ -239,12 +241,13 @@ jobs:
         uses: actions/cache/save@v3
         with:
           path: downloaded-artifacts
-          key: compiled-libs-${{ github.ref_name }}-${{ hashFiles('cpp-lib/conanfile.py', 'cpp-lib/conanprofile', 'cpp-lib/CMakeLists.txt', 'cpp-lib/src/**/*', 'cpp-lib/include/**/*', 'vendor/**/*') }}
+          key: compiled-libs-${{ hashFiles('cpp-lib/conanfile.py', 'cpp-lib/conanprofile', 'cpp-lib/CMakeLists.txt', 'cpp-lib/src/**/*', 'cpp-lib/include/**/*', 'vendor/**/*') }}
           if-no-files-found: error
 
   package:
     name: Package
     needs: consolidate
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -271,6 +274,7 @@ jobs:
   publish:
     name: Publish
     needs: package
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Download package directory

--- a/cpp-lib/include/pitaya/c_wrapper.h
+++ b/cpp-lib/include/pitaya/c_wrapper.h
@@ -1,5 +1,6 @@
 #include "pitaya.h"
 #include "pitaya/cluster.h"
+#include "pitaya/nats_config.h"
 
 #include <chrono>
 #include <string>
@@ -58,14 +59,17 @@ struct CGrpcConfig
 struct CNATSConfig
 {
     const char* addr;
-    int64_t connectionTimeoutMs;
-    int32_t requestTimeoutMs;
-    int32_t serverShutdownDeadlineMs;
-    int32_t serverMaxNumberOfRpcs;
-    int32_t maxReconnectionAttempts;
-    int32_t maxPendingMsgs;
-    int32_t reconnectBufSize;
-    int64_t reconnectWait = 2000;
+    int64_t connectionTimeoutMs = PITAYA_NATS_DEFAULT_CONNECTION_TIMEOUT_IN_MS;
+    int32_t requestTimeoutMs = PITAYA_NATS_DEFAULT_REQUEST_TIMEOUT_IN_MS;
+    int32_t serverShutdownDeadlineMs = PITAYA_NATS_DEFAULT_SERVER_SHUTDOWN_DEADLINE_IN_MS;
+    int32_t serverMaxNumberOfRpcs = PITAYA_NATS_DEFAULT_SERVER_MAX_NUMBER_OF_RPCS;
+    int32_t maxReconnectionAttempts = PITAYA_NATS_DEFAULT_MAX_RECONNECTION_ATTEMPTS;
+    int32_t maxPendingMsgs = PITAYA_NATS_DEFAULT_MAX_PENDING_MSGS;
+    int32_t reconnectBufSize = PITAYA_NATS_DEFAULT_RECONNECT_BUF_SIZE;
+    int64_t reconnectWaitInMs = PITAYA_NATS_DEFAULT_RECONNECT_WAIT_IN_MS;
+    int64_t reconnectJitterInMs = PITAYA_NATS_DEFAULT_RECONNECT_JITTER_IN_MS;
+    int64_t pingIntervalInMs = PITAYA_NATS_DEFAULT_PING_INTERVAL_IN_MS;
+    int32_t maxPingsOut = PITAYA_NATS_DEFAULT_MAX_PINGS_OUT;
 };
 
 struct CBindingStorageConfig

--- a/cpp-lib/include/pitaya/nats_config.h
+++ b/cpp-lib/include/pitaya/nats_config.h
@@ -4,12 +4,25 @@
 #include <chrono>
 #include <string>
 
+// Pitaya default values overriding nats defaults
+#define PITAYA_NATS_DEFAULT_CONNECTION_TIMEOUT_IN_MS 2000
+#define PITAYA_NATS_DEFAULT_REQUEST_TIMEOUT_IN_MS 2000
+#define PITAYA_NATS_DEFAULT_SERVER_SHUTDOWN_DEADLINE_IN_MS 2000
+#define PITAYA_NATS_DEFAULT_SERVER_MAX_NUMBER_OF_RPCS 500
+#define PITAYA_NATS_DEFAULT_MAX_RECONNECTION_ATTEMPTS 30
+#define PITAYA_NATS_DEFAULT_MAX_PENDING_MSGS 100
+
+// Reconnection parameters
+#define PITAYA_NATS_DEFAULT_RECONNECT_WAIT_IN_MS 100
+#define PITAYA_NATS_DEFAULT_RECONNECT_BUF_SIZE 8 * 1024 * 1024
+#define PITAYA_NATS_DEFAULT_RECONNECT_JITTER_IN_MS 50
+#define PITAYA_NATS_DEFAULT_PING_INTERVAL_IN_MS 1000
+#define PITAYA_NATS_DEFAULT_MAX_PINGS_OUT 2
+
 namespace pitaya {
 
 struct NatsConfig
 {
-    // TODO make more nats configs in both client and server
-    // like buffer size, connection retries, etc
     std::string natsAddr;
     std::chrono::milliseconds connectionTimeout;
     std::chrono::milliseconds requestTimeout;
@@ -17,8 +30,12 @@ struct NatsConfig
     int serverMaxNumberOfRpcs;
     int maxReconnectionAttempts;
     int maxPendingMsgs;
-    int reconnectWait;
+    // Reconnect parameters
     int reconnectBufSize;
+    std::chrono::milliseconds reconnectWaitInMs;
+    std::chrono::milliseconds reconnectJitterInMs;
+    std::chrono::milliseconds pingIntervalInMs;
+    int maxPingsOut;
 
     NatsConfig(const std::string& addr,
                std::chrono::milliseconds requestTimeout,
@@ -27,8 +44,11 @@ struct NatsConfig
                int serverMaxNumberOfRpcs,
                int maxReconnectionAttempts,
                int maxPendingMsgs,
-               int reconnectWait,
-               int reconnectBufSize)
+               std::chrono::milliseconds reconnectWaitInMs,
+               int reconnectBufSize,
+               std::chrono::milliseconds reconnectJitterInMs,
+               std::chrono::milliseconds pingIntervalInMs,
+               int maxPingsOut)
         : natsAddr(addr)
         , connectionTimeout(connectionTimeout)
         , requestTimeout(requestTimeout)
@@ -36,20 +56,29 @@ struct NatsConfig
         , serverMaxNumberOfRpcs(serverMaxNumberOfRpcs)
         , maxReconnectionAttempts(maxReconnectionAttempts)
         , maxPendingMsgs(maxPendingMsgs)
-        , reconnectWait(reconnectWait)
+        , reconnectWaitInMs(reconnectWaitInMs)
         , reconnectBufSize(reconnectBufSize)
-    {}
+        , reconnectJitterInMs(reconnectJitterInMs)
+        , pingIntervalInMs(pingIntervalInMs)
+        , maxPingsOut(maxPingsOut)
+    {
+    }
 
     NatsConfig()
-        : connectionTimeout(0)
-        , requestTimeout(0)
-        , serverShutdownDeadline(2000)
-        , serverMaxNumberOfRpcs(500)
-        , maxReconnectionAttempts(30)
-        , maxPendingMsgs(100)
-        , reconnectWait(2000)
-        , reconnectBufSize(4*1024*1024) // 4mb
-    {}
+        : connectionTimeout(std::chrono::milliseconds(PITAYA_NATS_DEFAULT_CONNECTION_TIMEOUT_IN_MS))
+        , requestTimeout(std::chrono::milliseconds(PITAYA_NATS_DEFAULT_REQUEST_TIMEOUT_IN_MS))
+        , serverShutdownDeadline(
+              std::chrono::milliseconds(PITAYA_NATS_DEFAULT_SERVER_SHUTDOWN_DEADLINE_IN_MS))
+        , serverMaxNumberOfRpcs(PITAYA_NATS_DEFAULT_SERVER_MAX_NUMBER_OF_RPCS)
+        , maxReconnectionAttempts(PITAYA_NATS_DEFAULT_MAX_RECONNECTION_ATTEMPTS)
+        , maxPendingMsgs(PITAYA_NATS_DEFAULT_MAX_PENDING_MSGS)
+        , reconnectWaitInMs(std::chrono::milliseconds(PITAYA_NATS_DEFAULT_RECONNECT_WAIT_IN_MS))
+        , reconnectBufSize(PITAYA_NATS_DEFAULT_RECONNECT_BUF_SIZE)
+        , reconnectJitterInMs(std::chrono::milliseconds(PITAYA_NATS_DEFAULT_RECONNECT_JITTER_IN_MS))
+        , pingIntervalInMs(std::chrono::milliseconds(PITAYA_NATS_DEFAULT_PING_INTERVAL_IN_MS))
+        , maxPingsOut(PITAYA_NATS_DEFAULT_MAX_PINGS_OUT)
+    {
+    }
 };
 
 } // namespace pitaya

--- a/cpp-lib/src/pitaya/c_wrapper.cpp
+++ b/cpp-lib/src/pitaya/c_wrapper.cpp
@@ -292,8 +292,11 @@ extern "C"
                                   nc->serverMaxNumberOfRpcs,
                                   nc->maxReconnectionAttempts,
                                   nc->maxPendingMsgs,
-                                  nc->reconnectWait,
-                                  nc->reconnectBufSize);
+                                  milliseconds(nc->reconnectWaitInMs),
+                                  nc->reconnectBufSize,
+                                  milliseconds(nc->reconnectJitterInMs),
+                                  milliseconds(nc->pingIntervalInMs),
+                                  nc->maxPingsOut);
         Server server = CServerToServer(sv);
 
         EtcdServiceDiscoveryConfig serviceDiscoveryConfig;

--- a/cpp-lib/src/pitaya/nats_client.cpp
+++ b/cpp-lib/src/pitaya/nats_client.cpp
@@ -71,14 +71,20 @@ NatsClientImpl::NatsClientImpl(NatsApiType apiType,
 
     natsOptions_SetTimeout(_opts, config.connectionTimeout.count());
     natsOptions_SetMaxReconnect(_opts, config.maxReconnectionAttempts);
-    natsOptions_SetReconnectWait(_opts, 2000);
-    natsOptions_SetReconnectBufSize(_opts, 8*1024*1024);
+
+    // Reconnect parameters
+    natsOptions_SetReconnectBufSize(_opts, config.reconnectBufSize);
+    natsOptions_SetReconnectWait(_opts, config.reconnectWaitInMs.count());
     natsOptions_SetRetryOnFailedConnect(_opts, true, NULL, this);
+    natsOptions_SetPingInterval(_opts, config.pingIntervalInMs.count());
+    natsOptions_SetMaxPingsOut(_opts, config.maxPingsOut);
+    natsOptions_SetReconnectJitter(
+        _opts, config.reconnectJitterInMs.count(), config.reconnectJitterInMs.count());
+
+    // Callbacks
     natsOptions_SetClosedCB(_opts, ClosedCb, this);
     natsOptions_SetDisconnectedCB(_opts, DisconnectedCb, this);
     natsOptions_SetReconnectedCB(_opts, ReconnectedCb, this);
-    natsOptions_SetPingInterval(_opts, 3000);
-    natsOptions_SetMaxPingsOut(_opts, 3);
     if (apiType == NatsApiType::Asynchronous) {
         natsOptions_SetMaxPendingMsgs(_opts, config.maxPendingMsgs);
         natsOptions_SetErrorHandler(_opts, ErrHandler, this);
@@ -87,8 +93,11 @@ NatsClientImpl::NatsClientImpl(NatsApiType apiType,
 
     _log->info("NATS Connection Timeout - " + std::to_string(config.connectionTimeout.count()));
     _log->info("NATS Max Reconnect Attempts - " + std::to_string(config.maxReconnectionAttempts));
-    _log->info("NATS Reconnect Wait Time - " + std::to_string(2000) + " //currently hardcoded ");
-    _log->info("NATS Reconnect Buffer Size - " + std::to_string(8*1024*1024) + " //currently hardcoded");
+    _log->info("NATS Reconnect Wait Time - " + std::to_string(config.reconnectWaitInMs.count()));
+    _log->info("NATS Reconnect Buffer Size - " + std::to_string(config.reconnectBufSize));
+    _log->info("NATS Ping Interval - " + std::to_string(config.pingIntervalInMs.count()));
+    _log->info("NATS Max Pings Out - " + std::to_string(config.maxPingsOut));
+    _log->info("NATS Reconnect Jitter - " + std::to_string(config.reconnectJitterInMs.count()));
 
     // TODO, FIXME: Change so that connection happens NOT in the constructor.
     status = natsConnection_Connect(&_conn, _opts);

--- a/cpp-lib/src/pitaya/nats_client.cpp
+++ b/cpp-lib/src/pitaya/nats_client.cpp
@@ -210,7 +210,7 @@ NatsClientImpl::ReconnectedCb(natsConnection* nc, void* user)
 {
     auto instance = reinterpret_cast<NatsClientImpl*>(user);
     // TODO: implement logic here
-    instance->_log->info("nats reconnected!");
+    instance->_log->warn("nats reconnected!");
 }
 
 void

--- a/cpp-lib/src/pitaya_cluster.cpp
+++ b/cpp-lib/src/pitaya_cluster.cpp
@@ -122,13 +122,19 @@ main()
                                                server,
                                                "main");
 #else
-        NatsConfig natsConfig(
-            "nats://localhost:4222", 
-            std::chrono::milliseconds(1000), 
-            std::chrono::milliseconds(3000), 
-            std::chrono::milliseconds(3), 100, 3, 10, 
-            4*1024*1024);
-        
+        NatsConfig natsConfig("nats://localhost:4222",
+                              std::chrono::milliseconds(1000),
+                              std::chrono::milliseconds(3000),
+                              std::chrono::milliseconds(3),
+                              100,
+                              3,
+                              10,
+                              std::chrono::milliseconds(100),
+                              4 * 1024 * 1024,
+                              std::chrono::milliseconds(50),
+                              std::chrono::milliseconds(1000),
+                              2);
+
         Cluster::Instance().InitializeWithNats(
             std::move(natsConfig), std::move(sdConfig), server, "main");
 #endif

--- a/pitaya-sharp/ExampleEFCore/src/App.cs
+++ b/pitaya-sharp/ExampleEFCore/src/App.cs
@@ -41,7 +41,6 @@ namespace ExampleORM
                 5000,
                 10 * 1000,
                 int.MaxValue,
-                3,
                 100,
                 8 * 1024 * 1024
             );

--- a/pitaya-sharp/NPitaya.Tests/Tests/Integration/NatsBackwardCompatibility.cs
+++ b/pitaya-sharp/NPitaya.Tests/Tests/Integration/NatsBackwardCompatibility.cs
@@ -1,0 +1,352 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using NPitaya;
+using Xunit;
+
+namespace NPitayaTest.Tests.Integration
+{
+    public class NatsBackwardCompatibility
+    {
+        [Fact]
+        public void Can_Use_Old_Constructor_With_MaxConnectionRetries()
+        {
+            var natsConfig = new NatsConfig(
+                endpoint: "nats://localhost:4222",
+                connectionTimeoutMs: 2000,
+                requestTimeoutMs: 2000,
+                serverShutdownDeadlineMs: 2000,
+                serverMaxNumberOfRpcs: 500,
+                maxPendingMessages: 100,
+                reconnectBufSize: 8 * 1024 * 1024,
+                maxReconnectionAttempts: 30,
+                reconnectWaitInMs: 100,
+                reconnectJitterInMs: 50,
+                pingIntervalInMs: 1000,
+                maxPingsOut: 2
+            );
+
+            // Verify the config was created correctly
+            Assert.Equal("nats://localhost:4222", natsConfig.endpoint);
+            Assert.Equal(2000, natsConfig.connectionTimeoutMs);
+            Assert.Equal(30, natsConfig.maxReconnectionAttempts);
+        }
+
+        [Fact]
+        public void Can_Use_New_Constructor_Without_MaxConnectionRetries()
+        {
+            var natsConfig = new NatsConfig(
+                endpoint: "nats://localhost:4222",
+                connectionTimeoutMs: 2000,
+                requestTimeoutMs: 2000,
+                serverShutdownDeadlineMs: 2000,
+                serverMaxNumberOfRpcs: 500,
+                maxPendingMessages: 100,
+                reconnectBufSize: 8 * 1024 * 1024,
+                maxReconnectionAttempts: 30,
+                reconnectWaitInMs: 100,
+                reconnectJitterInMs: 50,
+                pingIntervalInMs: 1000,
+                maxPingsOut: 2
+            );
+
+            Assert.Equal("nats://localhost:4222", natsConfig.endpoint);
+            Assert.Equal(2000, natsConfig.connectionTimeoutMs);
+            Assert.Equal(30, natsConfig.maxReconnectionAttempts);
+        }
+
+        [Fact]
+        public void Can_Use_Simple_Constructor_With_Defaults()
+        {
+            var natsConfig = new NatsConfig("nats://localhost:4222");
+
+            Assert.Equal("nats://localhost:4222", natsConfig.endpoint);
+            Assert.Equal(2000, natsConfig.connectionTimeoutMs);
+            Assert.Equal(2000, natsConfig.requestTimeoutMs);
+            Assert.Equal(2000, natsConfig.serverShutdownDeadlineMs);
+            Assert.Equal(500, natsConfig.serverMaxNumberOfRpcs);
+            Assert.Equal(100, natsConfig.maxPendingMessages);
+            Assert.Equal(8 * 1024 * 1024, natsConfig.reconnectBufSize);
+            Assert.Equal(30, natsConfig.maxReconnectionAttempts);
+            Assert.Equal(100, natsConfig.reconnectWaitInMs);
+            Assert.Equal(50, natsConfig.reconnectJitterInMs);
+            Assert.Equal(1000, natsConfig.pingIntervalInMs);
+            Assert.Equal(2, natsConfig.maxPingsOut);
+        }
+
+        [Fact]
+        public void Can_Use_Factory_Method_With_Defaults()
+        {
+            var natsConfig = NatsConfig.CreateWithDefaults("nats://localhost:4222");
+
+            Assert.Equal("nats://localhost:4222", natsConfig.endpoint);
+            Assert.Equal(2000, natsConfig.connectionTimeoutMs);
+            Assert.Equal(2000, natsConfig.requestTimeoutMs);
+            Assert.Equal(2000, natsConfig.serverShutdownDeadlineMs);
+            Assert.Equal(500, natsConfig.serverMaxNumberOfRpcs);
+            Assert.Equal(100, natsConfig.maxPendingMessages);
+            Assert.Equal(8 * 1024 * 1024, natsConfig.reconnectBufSize);
+            Assert.Equal(30, natsConfig.maxReconnectionAttempts);
+            Assert.Equal(100, natsConfig.reconnectWaitInMs);
+            Assert.Equal(50, natsConfig.reconnectJitterInMs);
+            Assert.Equal(1000, natsConfig.pingIntervalInMs);
+            Assert.Equal(2, natsConfig.maxPingsOut);
+        }
+
+        [Fact]
+        public void Can_Use_Constructor_With_Named_Parameters()
+        {
+            var natsConfig = new NatsConfig(
+                endpoint: "nats://localhost:4222",
+                connectionTimeoutMs: 5000,
+                requestTimeoutMs: 3000,
+                maxReconnectionAttempts: 50
+            );
+
+            Assert.Equal("nats://localhost:4222", natsConfig.endpoint);
+            Assert.Equal(5000, natsConfig.connectionTimeoutMs);
+            Assert.Equal(3000, natsConfig.requestTimeoutMs);
+            Assert.Equal(2000, natsConfig.serverShutdownDeadlineMs); // Default
+            Assert.Equal(500, natsConfig.serverMaxNumberOfRpcs); // Default
+            Assert.Equal(100, natsConfig.maxPendingMessages); // Default
+            Assert.Equal(8 * 1024 * 1024, natsConfig.reconnectBufSize); // Default
+            Assert.Equal(50, natsConfig.maxReconnectionAttempts); // Specified
+            Assert.Equal(100, natsConfig.reconnectWaitInMs); // Default
+            Assert.Equal(50, natsConfig.reconnectJitterInMs); // Default
+            Assert.Equal(1000, natsConfig.pingIntervalInMs); // Default
+            Assert.Equal(2, natsConfig.maxPingsOut); // Default
+        }
+
+        [Fact]
+        public void Deprecated_Parameter_Is_Ignored_In_New_Constructors()
+        {
+            var natsConfig1 = new NatsConfig(
+                endpoint: "nats://localhost:4222",
+                connectionTimeoutMs: 2000,
+                requestTimeoutMs: 2000,
+                serverShutdownDeadlineMs: 2000,
+                serverMaxNumberOfRpcs: 500,
+                maxPendingMessages: 100,
+                reconnectBufSize: 8 * 1024 * 1024,
+                maxReconnectionAttempts: 30, // This should be used
+                reconnectWaitInMs: 100,
+                reconnectJitterInMs: 50,
+                pingIntervalInMs: 1000,
+                maxPingsOut: 2
+            );
+
+            var natsConfig2 = new NatsConfig(
+                endpoint: "nats://localhost:4222",
+                connectionTimeoutMs: 2000,
+                requestTimeoutMs: 2000,
+                serverShutdownDeadlineMs: 2000,
+                serverMaxNumberOfRpcs: 500,
+                maxPendingMessages: 100,
+                reconnectBufSize: 8 * 1024 * 1024,
+                maxReconnectionAttempts: 30, // This should be used
+                reconnectWaitInMs: 100,
+                reconnectJitterInMs: 50,
+                pingIntervalInMs: 1000,
+                maxPingsOut: 2
+            );
+
+            // Both configs should have the same maxReconnectionAttempts value
+            Assert.Equal(natsConfig1.maxReconnectionAttempts, natsConfig2.maxReconnectionAttempts);
+            Assert.Equal(30, natsConfig1.maxReconnectionAttempts);
+            Assert.Equal(30, natsConfig2.maxReconnectionAttempts);
+        }
+
+        [Fact]
+        public void All_Constructors_Produce_Valid_Configs()
+        {
+            var configs = new[]
+            {
+                // Constructor with all parameters
+                new NatsConfig(
+                    endpoint: "nats://localhost:4222",
+                    connectionTimeoutMs: 2000,
+                    requestTimeoutMs: 2000,
+                    serverShutdownDeadlineMs: 2000,
+                    serverMaxNumberOfRpcs: 500,
+                    maxPendingMessages: 100,
+                    reconnectBufSize: 8 * 1024 * 1024,
+                    maxReconnectionAttempts: 30,
+                    reconnectWaitInMs: 100,
+                    reconnectJitterInMs: 50,
+                    pingIntervalInMs: 1000,
+                    maxPingsOut: 2
+                ),
+
+                // New constructor without maxConnectionRetries
+                new NatsConfig(
+                    endpoint: "nats://localhost:4222",
+                    connectionTimeoutMs: 2000,
+                    requestTimeoutMs: 2000,
+                    serverShutdownDeadlineMs: 2000,
+                    serverMaxNumberOfRpcs: 500,
+                    maxPendingMessages: 100,
+                    reconnectBufSize: 8 * 1024 * 1024,
+                    maxReconnectionAttempts: 30,
+                    reconnectWaitInMs: 100,
+                    reconnectJitterInMs: 50,
+                    pingIntervalInMs: 1000,
+                    maxPingsOut: 2
+                ),
+
+                new NatsConfig("nats://localhost:4222"),
+
+                NatsConfig.CreateWithDefaults("nats://localhost:4222")
+            };
+
+            foreach (var config in configs)
+            {
+                Assert.NotNull(config.endpoint);
+                Assert.True(config.connectionTimeoutMs > 0);
+                Assert.True(config.requestTimeoutMs > 0);
+                Assert.True(config.serverShutdownDeadlineMs > 0);
+                Assert.True(config.serverMaxNumberOfRpcs > 0);
+                Assert.True(config.maxPendingMessages > 0);
+                Assert.True(config.reconnectBufSize > 0);
+                Assert.True(config.maxReconnectionAttempts > 0);
+                Assert.True(config.reconnectWaitInMs > 0);
+                Assert.True(config.reconnectJitterInMs >= 0);
+                Assert.True(config.pingIntervalInMs > 0);
+                Assert.True(config.maxPingsOut > 0);
+            }
+        }
+
+        [Fact]
+        public void Can_Initialize_With_Old_Constructor_Format()
+        {
+            var natsConfig = new NatsConfig(
+                endpoint: "nats://localhost:4222",
+                connectionTimeoutMs: 1000,
+                requestTimeoutMs: 5000,
+                serverShutdownDeadlineMs: 10 * 1000,
+                serverMaxNumberOfRpcs: int.MaxValue,
+                maxPendingMessages: 100,
+                reconnectBufSize: 4 * 1024 * 1024,
+                maxReconnectionAttempts: 3,
+                reconnectWaitInMs: 1000,
+                reconnectJitterInMs: 100,
+                pingIntervalInMs: 1000,
+                maxPingsOut: 2
+            );
+
+            var sdCfg = new SDConfig(
+                endpoints: "127.0.0.1:123123123", // Invalid endpoint to force failure
+                etcdPrefix: "pitaya/",
+                serverTypeFilters: new List<string>(),
+                heartbeatTTLSec: 10,
+                logHeartbeat: false,
+                logServerSync: false,
+                logServerDetails: false,
+                syncServersIntervalSec: 10,
+                maxNumberOfRetries: 0,
+                retryDelayMilliseconds: 0
+            );
+
+            var server = new Server(
+                id: "id",
+                type: "type",
+                metadata: "",
+                hostname: "",
+                frontend: false
+            );
+
+            // Should fail initialization (expected due to invalid etcd endpoint)
+            // but the important thing is that it doesn't crash due to the deprecated parameter
+            Assert.Throws<PitayaException>(() =>
+            {
+                PitayaCluster.Initialize(natsConfig, sdCfg, server, NativeLogLevel.Debug);
+            });
+
+            PitayaCluster.Terminate();
+        }
+
+        [Fact]
+        public void Can_Initialize_With_New_Constructor_Format()
+        {
+            var natsConfig = new NatsConfig(
+                endpoint: "nats://localhost:4222",
+                connectionTimeoutMs: 1000,
+                requestTimeoutMs: 5000,
+                serverShutdownDeadlineMs: 10 * 1000,
+                serverMaxNumberOfRpcs: int.MaxValue,
+                maxPendingMessages: 100,
+                reconnectBufSize: 4 * 1024 * 1024,
+                maxReconnectionAttempts: 3,
+                reconnectWaitInMs: 1000,
+                reconnectJitterInMs: 100,
+                pingIntervalInMs: 1000,
+                maxPingsOut: 2
+            );
+
+            var sdCfg = new SDConfig(
+                endpoints: "127.0.0.1:123123123", // Invalid endpoint to force failure
+                etcdPrefix: "pitaya/",
+                serverTypeFilters: new List<string>(),
+                heartbeatTTLSec: 10,
+                logHeartbeat: false,
+                logServerSync: false,
+                logServerDetails: false,
+                syncServersIntervalSec: 10,
+                maxNumberOfRetries: 0,
+                retryDelayMilliseconds: 0
+            );
+
+            var server = new Server(
+                id: "id",
+                type: "type",
+                metadata: "",
+                hostname: "",
+                frontend: false
+            );
+
+            // Should fail initialization (expected due to invalid etcd endpoint)
+            // but the important thing is that it doesn't crash due to missing deprecated parameter
+            Assert.Throws<PitayaException>(() =>
+            {
+                PitayaCluster.Initialize(natsConfig, sdCfg, server, NativeLogLevel.Debug);
+            });
+
+            PitayaCluster.Terminate();
+        }
+
+        [Fact]
+        public void Can_Initialize_With_Simple_Constructor()
+        {
+            var natsConfig = new NatsConfig("nats://localhost:4222");
+
+            var sdCfg = new SDConfig(
+                endpoints: "127.0.0.1:123123123", // Invalid endpoint to force failure
+                etcdPrefix: "pitaya/",
+                serverTypeFilters: new List<string>(),
+                heartbeatTTLSec: 10,
+                logHeartbeat: false,
+                logServerSync: false,
+                logServerDetails: false,
+                syncServersIntervalSec: 10,
+                maxNumberOfRetries: 0,
+                retryDelayMilliseconds: 0
+            );
+
+            var server = new Server(
+                id: "id",
+                type: "type",
+                metadata: "",
+                hostname: "",
+                frontend: false
+            );
+
+            // Should fail initialization (expected due to invalid etcd endpoint)
+            // but the important thing is that it doesn't crash with simple constructor
+            Assert.Throws<PitayaException>(() =>
+            {
+                PitayaCluster.Initialize(natsConfig, sdCfg, server, NativeLogLevel.Debug);
+            });
+
+            PitayaCluster.Terminate();
+        }
+    }
+}

--- a/pitaya-sharp/NPitaya.Tests/Tests/Integration/NatsCluster.cs
+++ b/pitaya-sharp/NPitaya.Tests/Tests/Integration/NatsCluster.cs
@@ -18,9 +18,14 @@ namespace NPitayaTest.Tests.Integration
                 requestTimeoutMs: 5000,
                 serverShutdownDeadlineMs: 10 * 1000,
                 serverMaxNumberOfRpcs: int.MaxValue,
-                maxConnectionRetries: 3,
                 maxPendingMessages: 100,
-                reconnectBufSize: 4 * 1024 * 1024);
+                reconnectBufSize: 4 * 1024 * 1024,
+                maxReconnectionAttempts: 3,
+                reconnectWaitInMs: 1000,
+                reconnectJitterInMs: 100,
+                pingIntervalInMs: 1000,
+                maxPingsOut: 2
+            );
 
             var sdCfg = new SDConfig(
                 endpoints: "127.0.0.1:123123123",
@@ -63,9 +68,15 @@ namespace NPitayaTest.Tests.Integration
                 requestTimeoutMs: 5000,
                 serverShutdownDeadlineMs: 10 * 1000,
                 serverMaxNumberOfRpcs: int.MaxValue,
-                maxConnectionRetries: 3,
                 maxPendingMessages: 100,
-                reconnectBufSize: 4 * 1024 * 1024);
+                reconnectBufSize: 4 * 1024 * 1024,
+                maxReconnectionAttempts: 3,
+                reconnectWaitInMs: 1000,
+                reconnectJitterInMs: 100,
+                pingIntervalInMs: 1000,
+                maxPingsOut: 2
+            );
+
 
             var sdCfg = new SDConfig(
                 endpoints: "http://127.0.0.1:2379",

--- a/pitaya-sharp/NPitaya/Runtime/NativeInterop.cs
+++ b/pitaya-sharp/NPitaya/Runtime/NativeInterop.cs
@@ -189,27 +189,106 @@ namespace NPitaya
         public int requestTimeoutMs;
         public int serverShutdownDeadlineMs;
         public int serverMaxNumberOfRpcs;
-        public int maxConnectionRetries;
+        public int maxReconnectionAttempts;
         public int maxPendingMessages;
         public int reconnectBufSize;
+        public Int64 reconnectWaitInMs;
+        public Int64 reconnectJitterInMs;
+        public Int64 pingIntervalInMs;
+        public int maxPingsOut;
 
+        // Backward compatibility constructor with default values
+        [Obsolete("This constructor is deprecated. Use the constructor without maxConnectionRetries parameter or NatsConfig.CreateWithDefaults().")]
         public NatsConfig(string endpoint,
                           int connectionTimeoutMs,
                           int requestTimeoutMs,
                           int serverShutdownDeadlineMs,
                           int serverMaxNumberOfRpcs,
-                          int maxConnectionRetries,
+                          int maxConnectionRetries, // Deprecated parameter - ignored
                           int maxPendingMessages,
-                          int reconnectBufSize)
+                          int reconnectBufSize,
+                          int maxReconnectionAttempts = 30,
+                          int reconnectWaitInMs = 100,
+                          int reconnectJitterInMs = 50,
+                          int pingIntervalInMs = 1000,
+                          int maxPingsOut = 2)
         {
             this.endpoint = endpoint;
             this.connectionTimeoutMs = connectionTimeoutMs;
             this.requestTimeoutMs = requestTimeoutMs;
             this.serverShutdownDeadlineMs = serverShutdownDeadlineMs;
             this.serverMaxNumberOfRpcs = serverMaxNumberOfRpcs;
-            this.maxConnectionRetries = maxConnectionRetries;
+            this.maxReconnectionAttempts = maxReconnectionAttempts;
             this.maxPendingMessages = maxPendingMessages;
             this.reconnectBufSize = reconnectBufSize;
+            this.reconnectWaitInMs = reconnectWaitInMs;
+            this.reconnectJitterInMs = reconnectJitterInMs;
+            this.pingIntervalInMs = pingIntervalInMs;
+            this.maxPingsOut = maxPingsOut;
+        }
+
+        // Simple constructor for common use case
+        public NatsConfig(string endpoint)
+        {
+            this.endpoint = endpoint;
+            this.connectionTimeoutMs = 2000;
+            this.requestTimeoutMs = 2000;
+            this.serverShutdownDeadlineMs = 2000;
+            this.serverMaxNumberOfRpcs = 500;
+            this.maxReconnectionAttempts = 30;
+            this.maxPendingMessages = 100;
+            this.reconnectBufSize = 8 * 1024 * 1024;
+            this.reconnectWaitInMs = 100;
+            this.reconnectJitterInMs = 50;
+            this.pingIntervalInMs = 1000;
+            this.maxPingsOut = 2;
+        }
+
+        // New constructor without deprecated maxConnectionRetries parameter
+        public NatsConfig(string endpoint,
+                          int connectionTimeoutMs,
+                          int requestTimeoutMs,
+                          int serverShutdownDeadlineMs,
+                          int serverMaxNumberOfRpcs,
+                          int maxPendingMessages,
+                          int reconnectBufSize,
+                          int maxReconnectionAttempts = 30,
+                          int reconnectWaitInMs = 100,
+                          int reconnectJitterInMs = 50,
+                          int pingIntervalInMs = 1000,
+                          int maxPingsOut = 2)
+        {
+            this.endpoint = endpoint;
+            this.connectionTimeoutMs = connectionTimeoutMs;
+            this.requestTimeoutMs = requestTimeoutMs;
+            this.serverShutdownDeadlineMs = serverShutdownDeadlineMs;
+            this.serverMaxNumberOfRpcs = serverMaxNumberOfRpcs;
+            this.maxReconnectionAttempts = maxReconnectionAttempts;
+            this.maxPendingMessages = maxPendingMessages;
+            this.reconnectBufSize = reconnectBufSize;
+            this.reconnectWaitInMs = reconnectWaitInMs;
+            this.reconnectJitterInMs = reconnectJitterInMs;
+            this.pingIntervalInMs = pingIntervalInMs;
+            this.maxPingsOut = maxPingsOut;
+        }
+
+        // Static factory method for backward compatibility
+        public static NatsConfig CreateWithDefaults(string endpoint)
+        {
+            return new NatsConfig(
+                endpoint,
+                2000, // connectionTimeoutMs
+                2000, // requestTimeoutMs
+                2000, // serverShutdownDeadlineMs
+                500,  // serverMaxNumberOfRpcs
+                100,  // maxPendingMessages
+                8 * 1024 * 1024, // reconnectBufSize
+                30,   // maxReconnectionAttempts
+                100, // reconnectWaitInMs
+                50,   // reconnectJitterInMs
+                1000, // pingIntervalInMs
+                2     // maxPingsOut
+            );
         }
     }
 }

--- a/pitaya-sharp/exampleapp/Program.cs
+++ b/pitaya-sharp/exampleapp/Program.cs
@@ -44,7 +44,6 @@ namespace PitayaCSharpExample
           requestTimeoutMs: 1000,
           serverShutdownDeadlineMs: 3,
           serverMaxNumberOfRpcs: 100,
-          maxConnectionRetries: 3,
           maxPendingMessages: 1000,
           reconnectBufSize: 4 * 1024 * 1024);
 

--- a/unity/Assets/LibPitayaExample.cs
+++ b/unity/Assets/LibPitayaExample.cs
@@ -62,7 +62,6 @@ public class LibPitayaExample : MonoBehaviour {
 		    requestTimeoutMs: 2000,
 		    serverShutdownDeadlineMs: 4000,
 		    serverMaxNumberOfRpcs: 1000,
-		    maxConnectionRetries: 10,
 		    maxPendingMessages: 100,
           	reconnectBufSize: 4 * 1024 * 1024);
 


### PR DESCRIPTION
# fix(nats): tune reconnect params

Lower ping interval and max pings outstanding to detect faster when a nats node is down by pinging more frequently and requiring less PINGs to fail without PONG packets. Also, reduced jitter and reconnect wait. New default params are:

- Reconnect Wait: 100ms, time between reconnect attempts
- Reconnect Jitter: 50ms, jitter time added between reconnection attempts
- Max Pings Outstanding: 2, max PING packets without PONG packets to mark connection as stale
- Ping Interval: 1s, time between sending PING packets

Games should still set the connection timeout accordingly, as each reconnection attempt will respect that value.

Also, set the log level to reconnections to `warn` as it can cause disruptions to clients

# feat(nats): c_wrapper with new configs

Added the new configuration required by NatsConfig in the c_wrapper invocation. Apart from adding the new parameters, the main change was to pass reconnectWait as std::chrono::milliseconds instead of int

# feat(pitaya-sharp): reconnect params to NatsConfig

Added new NatsConfig constructions adding options to maintain current API but specifying default values for the new reconnection parameters. Also, created a new API to only specify the endpoint and initializing all other parameters with default values