### PR TITLE
Add ReportDistribution to IMetricsReporter

### DIFF
--- a/pitaya-sharp/NPitaya/Runtime/Metrics/IMetricsReporter.cs
+++ b/pitaya-sharp/NPitaya/Runtime/Metrics/IMetricsReporter.cs
@@ -7,5 +7,6 @@ namespace NPitaya.Metrics
         void ReportCount(string metricKey, Dictionary<string, string> labels, double value);
         void ReportGauge(string metricKey, Dictionary<string, string> labels, double value);
         void ReportSummary(string metricKey, Dictionary<string, string> labels, double value);
+        void ReportDistribution(string metricKey, Dictionary<string, string> labels, double value);
     }
 }

--- a/pitaya-sharp/NPitaya/Runtime/Metrics/MetricsReporters.cs
+++ b/pitaya-sharp/NPitaya/Runtime/Metrics/MetricsReporters.cs
@@ -57,5 +57,13 @@ namespace NPitaya.Metrics
             }
         }
 
+        public static void ReportDistribution(string key, Dictionary<string, string> tags, double value)
+        {
+            foreach (var reporter in _reporters)
+            {
+                reporter.ReportDistribution(key, tags, value);
+            }
+        }
+
     }
 }

--- a/pitaya-sharp/NPitaya/Runtime/Metrics/PrometheusMetricsReporter.cs
+++ b/pitaya-sharp/NPitaya/Runtime/Metrics/PrometheusMetricsReporter.cs
@@ -269,6 +269,15 @@ namespace NPitaya.Metrics
             summary.WithLabels(labelValues).Observe(value);
         }
 
+        public void ReportDistribution(string metricKey, Dictionary<string, string> tags, double value)
+        {
+            // Prometheus has no native Distribution type equivalent to Datadog's raw-sample Distribution
+            // (server-side percentile aggregation across clients). The closest analog is Summary, which
+            // computes quantiles client-side per process — so we forward to the summary path. Callers that
+            // rely on cross-process percentile aggregation must use the StatsD/Datadog reporter.
+            ReportSummary(metricKey, tags, value);
+        }
+
         private string[] _ensureLabels(Dictionary<string, string> labels, string[] labelNames)
         {
             var labelValues = new List<string>();

--- a/pitaya-sharp/NPitaya/Runtime/Metrics/StatsdMetricsReporter.cs
+++ b/pitaya-sharp/NPitaya/Runtime/Metrics/StatsdMetricsReporter.cs
@@ -50,5 +50,11 @@ namespace NPitaya.Metrics
             var parsedTags = _dictTagsToStringSlice(tags);
             DogStatsd.Timer(metricKey, value, tags:parsedTags);
         }
+
+        public void ReportDistribution(string metricKey, Dictionary<string, string> tags, double value)
+        {
+            var parsedTags = _dictTagsToStringSlice(tags);
+            DogStatsd.Distribution(metricKey, value, tags:parsedTags);
+        }
     }
 }


### PR DESCRIPTION
## Why

Datadog's Distribution metric type sends raw samples to Datadog and aggregates percentiles server-side, so queries can compute any percentile across all reporting pods. The existing `ReportSummary` method wraps `DogStatsd.Timer`, which client-aggregates to five fixed stats (`.avg`, `.max`, `.median`, `.95pc`, `.count`) per pod — those cannot be correctly aggregated fleet-wide.

Games built on this package need fleet-wide percentile aggregation for sampled signals like per-match server tick duration, connection-quality distributions, and per-peer RTT. With the current API shape, we're forced to either:

1. Use `ReportSummary` and lose the ability to compute a true fleet p99, or
2. Vendor the UPM package and hand-roll the emission.

## What

Adds `ReportDistribution(metricKey, tags, value)` to:

- **`IMetricsReporter`** — new interface method.
- **`StatsdMetricsReporter`** — implementation calls `DogStatsd.Distribution(...)`. Same parameter shape as the existing `Report*` methods.
- **`PrometheusMetricsReporter`** — forwards to `ReportSummary` since Prometheus has no native raw-sample-distribution equivalent. Prometheus users who need cross-process percentile aggregation must use the StatsD/Datadog reporter. Documented with a code comment.
- **`MetricsReporters`** — static dispatcher that calls `ReportDistribution` on every registered reporter, matching the existing `Report*` pattern.

## Backwards compatibility

Purely additive — existing callers keep working unchanged. The Prometheus fallback behavior is a minor semantic difference (forward to Summary); alternatives would have been `NotImplementedException` (breaks Prometheus callers who opt into using it) or a silent no-op (harder to debug). Forwarding matches user expectation that `Report*` methods always record something.

## Testing

Source-level change only, no behavioral test added in this patch. Consumer projects will exercise the new method when they call `MetricsReporters.ReportDistribution(...)` on the server side. Happy to add a smoke test under `NPitaya.Tests/Metric/` if the maintainers prefer.

## Release

Once merged, tag (e.g. `v1.1.1`) so the CI publishes to Artifactory at `com.wildlifestudios.npitaya@1.1.1`. Consumer repos can then bump their package manifest entry.